### PR TITLE
fix: spelling error in Options > Global Hotkeys

### DIFF
--- a/Keyboard and Spell checker/Forms/ufrmOptions.dfm
+++ b/Keyboard and Spell checker/Forms/ufrmOptions.dfm
@@ -968,7 +968,7 @@ object frmOptions: TfrmOptions
           Top = 25
           Width = 165
           Height = 13
-          Caption = 'Keyboard mode switcing key:'
+          Caption = 'Keyboard mode switching key:'
           Font.Charset = DEFAULT_CHARSET
           Font.Color = clWindowText
           Font.Height = -11


### PR DESCRIPTION
**Context**

This spelling mistake bugged me a lot when I first saw it! Check the diff, it's just a label change.